### PR TITLE
Update readme/classifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,12 @@ Requirements
 
 * OMERO 5.2.6 or newer.
 
-Installation
-============
+Installing from Pypi
+====================
 
-This section assumes that an OMERO.server is already installed.
+This section assumes that an OMERO.web is already installed.
 
-Install the app:
+Install the app using `pip <https://pip.pypa.io/en/stable/>`_:
 
 ::
 
@@ -37,7 +37,7 @@ Now restart OMERO.web as normal.
 **Warning**:
 
 OMERO.gallery version 2.x requires OMERO.web **5.2.6 or newer**.
-This is due to Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed using Python Package Manager PyPi.
+This is due to a Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed from Python Package Index `PyPi <https://https://pypi.python.org/pypi>`_.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Now restart OMERO.web as normal.
 **Warning**:
 
 OMERO.gallery version 2.x requires OMERO.web **5.2.6 or newer**.
-This is due to a Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed from Python Package Index `PyPi <https://https://pypi.python.org/pypi>`_.
+This is due to a Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed from Python Package Index `PyPi <https://pypi.python.org/pypi>`_.
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This is an OMERO.web plugin (Django app) that provides a 'gallery' view of image
 Requirements
 ============
 
-* OMERO 5.1.0 or later.
+* OMERO 5.2.6 or newer.
 
 Installation
 ============
@@ -36,9 +36,8 @@ Now restart OMERO.web as normal.
 
 **Warning**:
 
-if OMERO.gallery is installed with OMERO version prior to **5.2.6**,
-the url will be https://your-web-server/omero_gallery instead of https://your-web-server/gallery as previously. This is due to a package re-organization required to distribute the application using a package manager.
-If installed with OMERO **5.2.6 and older**, the url will be back to https://your-web-server/gallery.
+OMERO.weberror version 2.x or newer is meant to be installed into OMERO.web **5.2.6 or newer**. This is due to Django Framework compatibility and a package re-organization required to distribute the application using Python Package Manager PyPi.
+
 
 OMERO.gallery overview
 ======================

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Now restart OMERO.web as normal.
 
 **Warning**:
 
-OMERO.weberror version 2.x or newer is meant to be installed into OMERO.web **5.2.6 or newer**. This is due to Django Framework compatibility and a package re-organization required to distribute the application using Python Package Manager PyPi.
+OMERO.weberror version 2.x or newer is meant to be installed into OMERO.web **5.2.6 or newer**. This is due to Django Framework compatibility and a package reorganization required to distribute the application using Python Package Manager PyPi.
 
 
 OMERO.gallery overview

--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,15 @@ OMERO.gallery
 
 This is an OMERO.web plugin (Django app) that provides a 'gallery' view of images in OMERO, ideal for public browsing without editing.
 
+Requirements
+============
+
+* OMERO 5.1.0 or later.
 
 Installation
 ============
 
-Install OMERO.web
+Install OMERO.web.
 
 This app installs into the OMERO.web framework.
 
@@ -30,9 +34,11 @@ Add gallery custom app to your installed web apps:
 Now restart OMERO.web as normal.
 
 
-And you're done! Go to https://your-web-server/gallery
+**Warning**:
 
-
+if OMERO.gallery is installed with OMERO version prior to **5.2.6**,
+the url will be https://your-web-server/omero_gallery instead of https://your-web-server/gallery as previously. This is due to a package re-organization required to distribute the application using a package manager.
+If installed with OMERO **5.2.6 and older**, the url will be back to https://your-web-server/gallery.
 
 OMERO.gallery overview
 ======================

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Requirements
 Installation
 ============
 
-Install OMERO.web.
+This section assumes that an OMERO.server is already installed.
 
-This app installs into the OMERO.web framework.
+Install the app:
 
 ::
 
@@ -36,7 +36,9 @@ Now restart OMERO.web as normal.
 
 **Warning**:
 
-OMERO.weberror version 2.x or newer is meant to be installed into OMERO.web **5.2.6 or newer**. This is due to Django Framework compatibility and a package reorganization required to distribute the application using Python Package Manager PyPi.
+OMERO.gallery version 2.x requires OMERO.web **5.2.6 or newer**.
+This is due to Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed using Python Package Manager PyPi.
+
 
 
 OMERO.gallery overview

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Requirements
 
 * OMERO 5.2.6 or newer.
 
-Installing from Pypi
+Installing from PyPI
 ====================
 
 This section assumes that an OMERO.web is already installed.
@@ -37,7 +37,7 @@ Now restart OMERO.web as normal.
 **Warning**:
 
 OMERO.gallery version 2.x requires OMERO.web **5.2.6 or newer**.
-This is due to a Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed from Python Package Index `PyPi <https://pypi.python.org/pypi>`_.
+This is due to a Django Framework compatibility and to a required package reorganization in OMERO.gallery in version 2.0 so the application can be distributed from Python Package Index `PyPI <https://pypi.python.org/pypi>`_.
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 
 setup(name="omero-gallery",

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,27 @@ setup(name="omero-gallery",
       version=VERSION,
       description="A Python plugin for OMERO.web",
       long_description=read('README.rst'),
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Environment :: Web Environment',
+          'Framework :: Django',
+          'Intended Audience :: End Users/Desktop',
+          'Intended Audience :: Science/Research',
+          'License :: OSI Approved :: GNU Affero General Public License v3 '
+          'or later (AGPLv3+)',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Programming Language :: JavaScript',
+          'Programming Language :: Python :: 2',
+          'Topic :: Internet :: WWW/HTTP',
+          'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+          'Topic :: Internet :: WWW/HTTP :: WSGI',
+          'Topic :: Scientific/Engineering :: Visualization',
+          'Topic :: Software Development :: Libraries :: '
+          'Application Frameworks',
+          'Topic :: Text Processing :: Markup :: HTML'
+      ],  # Get strings from
+          # http://pypi.python.org/pypi?%3Aaction=list_classifiers
       author='The Open Microscopy Team',
       author_email='ome-devel@lists.openmicroscopy.org.uk',
       license='AGPLv3',


### PR DESCRIPTION
Clarify change in the url if installed with version prior to 5.2.6
This will require a version bump since the clarification should be pushed to pypi

I also have added classfiers
