### PR TITLE
Use full support URL for PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ OMERO.gallery
 
 This is an OMERO.web plugin (Django app) that provides a 'gallery' view of images in OMERO, ideal for public browsing without editing.
 
-Also see `SUPPORT.md <./SUPPORT.md>`_
+Also see `SUPPORT.md <https://github.com/ome/omero-gallery/blob/master/SUPPORT.md>`_
 
 Requirements
 ============


### PR DESCRIPTION
Se per https://github.com/ome/omero-figure/pull/267 this updates the README to use the full URL for the support file so that the link works from PyPI