### PR TITLE
HTML fixes

### DIFF
--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>IDR: {{ page.title }}</title>
+        <title>IDR: Image Data Resource</title>
         <link rel="shortcut icon" type="image/x-icon" href="https://idr.openmicroscopy.org/about/img/logos/favicon-idr.ico">
 
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -6,7 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>IDR: {{ page.title }}</title>
-        <link rel="shortcut icon" type="image/x-icon" href="http://idr.openmicroscopy.org/about/img/logos/favicon-idr.ico">
+        <link rel="shortcut icon" type="image/x-icon" href="https://idr.openmicroscopy.org/about/img/logos/favicon-idr.ico">
 
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Nunito">

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -37,7 +37,7 @@
             <div class="top-bar-left">
                 <ul class="dropdown menu" data-dropdown-menu>
                     <li><a class="logo" href="{% url 'webgallery_index' %}">
-                        <img src="http://idr.openmicroscopy.org/about/img/logos/logo-idr.svg" }}" alt="IDR logo"></a>
+                        <img src="https://idr.openmicroscopy.org/about/img/logos/logo-idr.svg" }}" alt="IDR logo"></a>
                     </li>
 
 


### PR DESCRIPTION
- Use https for favicon link to prevents browser warnings when loading gallery with https
- Fix truncated `<title>`