### PR TITLE
Show different subheading for /cell and /tissue

### DIFF
--- a/omero_gallery/static/gallery/categories.js
+++ b/omero_gallery/static/gallery/categories.js
@@ -230,7 +230,7 @@ function renderStudy(studyData, elementId, linkFunc) {
     }).join('\n');
   }
 
-  var idrId = studyData.Name.split('-')[0]; // idr0001
+  var idrId = studyData.Name.split('-')[0] + studyData.Name[studyData.Name.length - 1]; // idr0001A
 
   var authors = model.getStudyValue(studyData, "Publication Authors") || ""; // Function (and template) are defined where used in index.html
 

--- a/omero_gallery/static/gallery/model.js
+++ b/omero_gallery/static/gallery/model.js
@@ -195,7 +195,7 @@ StudiesModel.prototype.loadStudies = function loadStudies(callback) {
   var _this2 = this;
 
   // Load Projects AND Screens, sort them and render...
-  Promise.all([fetch(this.base_url + "api/v0/m/projects/"), fetch(this.base_url + "api/v0/m/screens/")]).then(function (responses) {
+  Promise.all([fetch(this.base_url + "api/v0/m/projects/?childCount=true"), fetch(this.base_url + "api/v0/m/screens/?childCount=true")]).then(function (responses) {
     return Promise.all(responses.map(function (res) {
       return res.json();
     }));
@@ -205,7 +205,11 @@ StudiesModel.prototype.loadStudies = function loadStudies(callback) {
         screens = _ref2[1];
 
     _this2.studies = projects.data;
-    _this2.studies = _this2.studies.concat(screens.data); // sort by name, reverse
+    _this2.studies = _this2.studies.concat(screens.data); // ignore empty studies with no images
+
+    _this2.studies = _this2.studies.filter(function (study) {
+      return study['omero:childCount'] > 0;
+    }); // sort by name, reverse
 
     _this2.studies.sort(function (a, b) {
       var nameA = a.Name.toUpperCase();

--- a/omero_gallery/static/gallery/model.js
+++ b/omero_gallery/static/gallery/model.js
@@ -233,7 +233,7 @@ StudiesModel.prototype.loadStudies = function loadStudies(callback) {
 StudiesModel.prototype.loadStudiesThumbnails = function loadStudiesThumbnails(ids, callback) {
   var _this3 = this;
 
-  var url = GALLERY_INDEX + "api/thumbnails/"; // remove duplicates
+  var url = GALLERY_INDEX + "gallery-api/thumbnails/"; // remove duplicates
 
   ids = _toConsumableArray(new Set(ids)); // find any thumbnails we already have in hand...
 
@@ -492,7 +492,7 @@ StudiesModel.prototype.getStudyImage = function getStudyImage(obj_type, obj_id, 
     return;
   }
 
-  var url = "".concat(GALLERY_INDEX, "api/").concat(obj_type, "s/").concat(obj_id, "/images/?limit=1");
+  var url = "".concat(GALLERY_INDEX, "gallery-api/").concat(obj_type, "s/").concat(obj_id, "/images/?limit=1");
   fetch(url).then(function (response) {
     return response.json();
   }).then(function (data) {

--- a/omero_gallery/static/gallery/search.js
+++ b/omero_gallery/static/gallery/search.js
@@ -555,7 +555,7 @@ function renderStudy(studyData, elementSelector, linkFunc, htmlFunc) {
     }).join('\n');
   }
 
-  var idrId = studyData.Name.split('-')[0]; // idr0001
+  var idrId = studyData.Name.split('-')[0] + studyData.Name[studyData.Name.length - 1]; // idr0001A
 
   var authors = model.getStudyValue(studyData, "Publication Authors") || "";
   var div = htmlFunc({

--- a/omero_gallery/templates/webgallery/categories/index.html
+++ b/omero_gallery/templates/webgallery/categories/index.html
@@ -20,8 +20,13 @@
   {% if gallery_title %}<h1>{{ gallery_title }}</h1>{% endif %}
 
   <p>
-    The Image Data Resource (IDR) is a public repository of image datasets from published scientific studies,<br/>
-    where the community can submit, search and access high-quality bio-image data.
+    {% if not super_category %}
+      The Image Data Resource (IDR) is a public repository of image datasets from published scientific studies,<br/>
+      where the community can submit, search and access high-quality bio-image data.
+    {% else %}
+      The Image Data Resource (IDR) is a public repository of reference image datasets from published scientific studies.<br>
+      IDR enables access, search and analysis of these highly annotated datasets.
+    {% endif %}
   </p>
 <div class="small-10 small-centered medium-10 medium-centered columns">
 

--- a/omero_gallery/urls.py
+++ b/omero_gallery/urls.py
@@ -38,12 +38,12 @@ urlpatterns = patterns(
     url(r'^search/$', views.search, {'super_category': None}),
 
     # list images within container. NB: not used but potentially useful
-    url(r'^api/(?P<obj_type>[screen|project]+)s/'
+    url(r'^gallery-api/(?P<obj_type>[screen|project]+)s/'
         r'(?P<obj_id>[0-9]+)/images/$',
         views.study_images, name='webgallery_study_image'),
 
     # Supports e.g. ?project=1&project=2&screen=3
-    url(r'^api/thumbnails/$', views.api_thumbnails,
+    url(r'^gallery-api/thumbnails/$', views.api_thumbnails,
         name='webgallery_api_thumbnails'),
 )
 

--- a/src/categories.js
+++ b/src/categories.js
@@ -233,7 +233,7 @@ function renderStudy(studyData, elementId, linkFunc) {
       .join('\n');
   }
 
-  let idrId = studyData.Name.split('-')[0];  // idr0001
+  let idrId = studyData.Name.split('-')[0] + studyData.Name[studyData.Name.length-1];  // idr0001A
   let authors = model.getStudyValue(studyData, "Publication Authors") || "";
 
   // Function (and template) are defined where used in index.html

--- a/src/model.js
+++ b/src/model.js
@@ -155,13 +155,16 @@ StudiesModel.prototype.loadStudies = function loadStudies(callback) {
 
   // Load Projects AND Screens, sort them and render...
   Promise.all([
-    fetch(this.base_url + "api/v0/m/projects/"),
-    fetch(this.base_url + "api/v0/m/screens/"),
+    fetch(this.base_url + "api/v0/m/projects/?childCount=true"),
+    fetch(this.base_url + "api/v0/m/screens/?childCount=true"),
   ]).then(responses =>
       Promise.all(responses.map(res => res.json()))
   ).then(([projects, screens]) => {
       this.studies = projects.data;
       this.studies = this.studies.concat(screens.data);
+
+      // ignore empty studies with no images
+      this.studies = this.studies.filter(study => study['omero:childCount'] > 0);
 
       // sort by name, reverse
       this.studies.sort(function(a, b) {

--- a/src/model.js
+++ b/src/model.js
@@ -188,7 +188,7 @@ StudiesModel.prototype.loadStudies = function loadStudies(callback) {
 
 
 StudiesModel.prototype.loadStudiesThumbnails = function loadStudiesThumbnails(ids, callback) {
-  let url = GALLERY_INDEX + "api/thumbnails/";
+  let url = GALLERY_INDEX + "gallery-api/thumbnails/";
   // remove duplicates
   ids = [...new Set(ids)];
   // find any thumbnails we already have in hand...
@@ -415,7 +415,7 @@ StudiesModel.prototype.getStudyImage = function getStudyImage(obj_type, obj_id, 
     return;
   }
 
-  let url = `${ GALLERY_INDEX }api/${obj_type}s/${ obj_id }/images/?limit=1`
+  let url = `${ GALLERY_INDEX }gallery-api/${obj_type}s/${ obj_id }/images/?limit=1`
   fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/src/search.js
+++ b/src/search.js
@@ -545,7 +545,7 @@ function renderStudy(studyData, elementSelector, linkFunc, htmlFunc) {
       .join('\n');
   }
 
-  let idrId = studyData.Name.split('-')[0];  // idr0001
+  let idrId = studyData.Name.split('-')[0] + studyData.Name[studyData.Name.length-1];  // idr0001A
   let authors = model.getStudyValue(studyData, "Publication Authors") || "";
 
   let div = htmlFunc({studyLink, studyDesc, idrId, title, authors, BASE_URL, type}, studyData);


### PR DESCRIPTION
 - Tweak the text on /cell and /tissue pages.
 - Remove empty studies from /gallery/ e.g.  ```/search/?query=Name:idr0028``` shouldn't show the empty idr0028 study.
