### PR TITLE
Support external hosting, synchronise with idr.openmicroscopy.org

### DIFF
--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -6,13 +6,13 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>IDR: Image Data Resource</title>
-        <link rel="shortcut icon" type="image/x-icon" href="/about/img/logos/favicon-idr.ico">
+        <link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}about/img/logos/favicon-idr.ico">
 
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Nunito">
-        <link href="/about/css/foundation.min.css" rel="stylesheet">
-        <link href="/about/css/openmicroscopy.css" rel="stylesheet">
-        <link href="/about/css/idr.css" rel="stylesheet">
+        <link href="{{ base_url }}about/css/foundation.min.css" rel="stylesheet">
+        <link href="{{ base_url }}about/css/openmicroscopy.css" rel="stylesheet">
+        <link href="{{ base_url }}about/css/idr.css" rel="stylesheet">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
         <!-- fetch polyfill for IE -->
         <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd.min.js"></script>
@@ -22,7 +22,8 @@
         <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
         <link href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" rel="stylesheet">
 
-        <script src="/about/js/vendor/foundation.min.js"></script>
+        <script src="{{ base_url }}about/js/vendor/foundation.min.js"></script>
+
 
         <script src="{% static 'gallery/model.js' %}"></script>
         <link href="{% static 'gallery/studies.css' %}" rel="stylesheet">
@@ -43,7 +44,7 @@
             <div class="top-bar-left">
                 <ul class="dropdown menu" data-dropdown-menu>
                     <li><a class="logo" href="{% url 'webgallery_index' %}">
-                        <img src="/about/img/logos/logo-idr.svg" alt="IDR logo"></a>
+                        <img src="{{ base_url }}about/img/logos/logo-idr.svg" alt="IDR logo"></a>
                     </li>
 
 
@@ -59,22 +60,22 @@
 
             <div class="top-bar-right">
                 <ul class="dropdown menu" data-dropdown-menu>
-                    <li class="has-submenu"><a href="/about/index.html">About</a>
+                    <li class="has-submenu"><a href="{{ base_url }}about/index.html">About</a>
                         <ul class="submenu menu vertical" data-submenu>
-                            <li><a href="/about/index.html">Overview</a></li>
-                            <li><a href="/about/studies.html">Published studies</a></li>
-                            <li><a href="/about/api.html">API Access</a></li>
-                            <li><a href="/about/download.html">Data download</a></li>
-                            <li><a href="/about/itr.html">Image Tools Resource (ITR)</a></li>
+                            <li><a href="{{ base_url }}about/index.html">Overview</a></li>
+                            <li><a href="{{ base_url }}about/studies.html">Published studies</a></li>
+                            <li><a href="{{ base_url }}about/api.html">API Access</a></li>
+                            <li><a href="{{ base_url }}about/download.html">Data download</a></li>
+                            <li><a href="{{ base_url }}about/itr.html">Image Tools Resource (ITR)</a></li>
                             <li><a href="/jupyter">Virtual Analysis Environment (VAE)</a></li>
-                            <li><a href="/about/deployment.html">Deployment</a></li>
+                            <li><a href="{{ base_url }}about/deployment.html">Deployment</a></li>
                         </ul>
                     </li>
-                    <li class="has-submenu"><a href="/about/submission.html">Submissions</a>
+                    <li class="has-submenu"><a href="{{ base_url }}about/submission.html">Submissions</a>
                         <ul class="submenu menu vertical" data-submenu>
-                            <li><a href="/about/submission.html">Overview</a></li>
-                            <li><a href="/about/screens.html">Screens</a></li>
-                            <li><a href="/about/experiments.html">Experiments</a></li>
+                            <li><a href="{{ base_url }}about/submission.html">Overview</a></li>
+                            <li><a href="{{ base_url }}about/screens.html">Screens</a></li>
+                            <li><a href="{{ base_url }}about/experiments.html">Experiments</a></li>
                         </ul>
                     </li>
                 </ul>
@@ -93,11 +94,11 @@
         <div class="callout large secondary">
             <div class="row">
                 <div class="row small-up-2 medium-up-5 large-up-5">
-                    <div class="column"><a href="https://www.openmicroscopy.org/" target="_blank"><img class="thumbnail their-logo" src="/about/img/logos/ome-logo-200.png?1554986584537045008" alt="OME"></a></div>
-                    <div class="column"><a href="http://www.eurobioimaging.eu/" target="_blank"><img class="thumbnail their-logo" src="/about/img/logos/eurobioimaging_logo.gif?1554986584537045008" alt="Euro-Bioimaging"></a></div>
-                    <div class="column"><a href="https://www.globalbioimaging.org/" target="_blank"><img class="thumbnail their-logo" src="/about/img/logos/globalbioimaging_logo.png?1554986584537045008" alt="Global-Bioimaging"></a></div>
-                    <div class="column"><a href="https://www.bbsrc.ac.uk/" target="_blank"><img class="thumbnail their-logo" src="/about/img/logos/bbsrc.png?1554986584537045008" alt="BBSRC"></a></div>
-                    <div class="column"><a href="https://ec.europa.eu/programmes/horizon2020/" target="_blank"><img class="thumbnail their-logo" src="/about/img/logos/h2020.png?1554986584537045008" alt="Horizon"></a></div>
+                    <div class="column"><a href="https://www.openmicroscopy.org/" target="_blank"><img class="thumbnail their-logo" src="{{ base_url }}about/img/logos/ome-logo-200.png" alt="OME"></a></div>
+                    <div class="column"><a href="http://www.eurobioimaging.eu/" target="_blank"><img class="thumbnail their-logo" src="{{ base_url }}about/img/logos/eurobioimaging_logo.gif" alt="Euro-Bioimaging"></a></div>
+                    <div class="column"><a href="https://www.globalbioimaging.org/" target="_blank"><img class="thumbnail their-logo" src="{{ base_url }}about/img/logos/globalbioimaging_logo.png" alt="Global-Bioimaging"></a></div>
+                    <div class="column"><a href="https://www.bbsrc.ac.uk/" target="_blank"><img class="thumbnail their-logo" src="{{ base_url }}about/img/logos/bbsrc.png" alt="BBSRC"></a></div>
+                    <div class="column"><a href="https://ec.europa.eu/programmes/horizon2020/" target="_blank"><img class="thumbnail their-logo" src="{{ base_url }}about/img/logos/h2020.png" alt="Horizon"></a></div>
                 </div>
                 <hr class="whitespace">
                 <div class="large-12 columns text-center">

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -10,10 +10,10 @@
 
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Nunito">
+        <link rel="stylesheet" type="text/css" media="all" href="{{ base_url }}about/css/font-awesome.min.css">
         <link href="{{ base_url }}about/css/foundation.min.css" rel="stylesheet">
         <link href="{{ base_url }}about/css/openmicroscopy.css" rel="stylesheet">
         <link href="{{ base_url }}about/css/idr.css" rel="stylesheet">
-        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
         <!-- fetch polyfill for IE -->
         <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd.min.js"></script>
         <!-- Babel polfill (Symbol, Promise) -->

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -23,6 +23,7 @@
         <link href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css" rel="stylesheet">
 
         <script src="{{ base_url }}about/js/vendor/foundation.min.js"></script>
+        <script src="{{ base_url }}about/js/version.js"></script>
 
 
         <script src="{% static 'gallery/model.js' %}"></script>

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -31,15 +31,6 @@
 
     <body>
 
-        <div class="nav-secondary">
-            <div class="top-bar-right">
-                <ul class="menu">
-                    <li><a href="https://www.twitter.com/idrnews" target="_blank"><i class="fab fa-twitter"></i> @IDRnews</a></li>
-                    <li><a href="https://www.twitter.com/idrstatus" target="_blank"><i class="fab fa-twitter"></i> @IDRstatus</a></li>
-                </ul>
-            </div>
-        </div>
-
         <div class="main-nav-bar top-bar" id="main-menu">
             <div class="top-bar-left">
                 <ul class="dropdown menu" data-dropdown-menu>
@@ -106,10 +97,15 @@
                     <p>OMERO is distributed under the terms of the GNU GPL. For more information, visit <a href="https://www.openmicroscopy.org">openmicroscopy.org</a></p>
                 </div>
                 <hr class="whitespace">
-                <div class="small-12 columns text-center">
-                    <p class="version-number"><a href="/about/index.html"><img id="version-number" src="/about/img/logos/logo-idr.svg?1554986584537045008" alt="IDR logo"></a>
-                        version: <span id="version-number-display">devel</span>.
-                    Last updated: 2019-04-11.
+                <div>
+                    <div class="version-number float-left">
+                        <a href="{{ base_url }}"><img id="version-number" src="{{ base_url }}about/img/logos/logo-idr.svg" alt="IDR logo"></a>
+                        version: <span id="version-number-display"></span>.
+                    </div>
+                    <div class="float-right">
+                        <a href="https://www.twitter.com/idrnews" target="_blank"><i class="fa fa-fw fa-twitter"></i> @IDRnews</a></li>
+                        <a href="https://www.twitter.com/idrstatus" target="_blank"><i class="fa fa-fw fa-twitter"></i> @IDRstatus</a></li>
+                    </div>
                 </div>
             </div>
         </div>

--- a/omero_gallery/templates/webgallery/categories/base.html
+++ b/omero_gallery/templates/webgallery/categories/base.html
@@ -10,10 +10,10 @@
 
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic">
         <link rel="stylesheet" type="text/css" media="all" href="//fonts.googleapis.com/css?family=Nunito">
-        <link rel="stylesheet" type="text/css" media="all" href="{{ base_url }}about/css/font-awesome.min.css">
         <link href="{{ base_url }}about/css/foundation.min.css" rel="stylesheet">
         <link href="{{ base_url }}about/css/openmicroscopy.css" rel="stylesheet">
         <link href="{{ base_url }}about/css/idr.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
         <!-- fetch polyfill for IE -->
         <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd.min.js"></script>
         <!-- Babel polfill (Symbol, Promise) -->
@@ -104,8 +104,8 @@
                         version: <span id="version-number-display"></span>.
                     </div>
                     <div class="float-right">
-                        <a href="https://www.twitter.com/idrnews" target="_blank"><i class="fa fa-fw fa-twitter"></i> @IDRnews</a></li>
-                        <a href="https://www.twitter.com/idrstatus" target="_blank"><i class="fa fa-fw fa-twitter"></i> @IDRstatus</a></li>
+                        <a href="https://www.twitter.com/idrnews" target="_blank"><i class="fab fa-fw fa-twitter"></i> @IDRnews</a></li>
+                        <a href="https://www.twitter.com/idrstatus" target="_blank"><i class="fab fa-fw fa-twitter"></i> @IDRstatus</a></li>
                     </div>
                 </div>
             </div>

--- a/omero_gallery/templates/webgallery/categories/index.html
+++ b/omero_gallery/templates/webgallery/categories/index.html
@@ -23,11 +23,10 @@
     {% if not super_category %}
       The Image Data Resource (IDR) is a public repository of image datasets from published scientific studies,<br/>
       where the community can submit, search and access high-quality bio-image data.
-    {% else %}
-      The Image Data Resource (IDR) is a public repository of reference image datasets from published scientific studies.<br>
-      IDR enables access, search and analysis of these highly annotated datasets.
     {% endif %}
   </p>
+</div>
+
 <div class="small-10 small-centered medium-10 medium-centered columns">
 
     <div class="row horizontal">


### PR DESCRIPTION
- Synchonises gallery IDR customisations with https://github.com/IDR/idr.openmicroscopy.org/pull/58
- Uses `omero.web.gallery.base_url` in Django base.html template. This means it should be possible to fully view and test gallery on web-dev-merge by setting `omero.web.gallery.base_url=https://idr-test-server/`. Note idr-prod will require `omero.web.gallery.base_url=/`.