### PR TITLE
gallery login required

### DIFF
--- a/omero_gallery/views.py
+++ b/omero_gallery/views.py
@@ -21,8 +21,9 @@ logger = logging.getLogger(__name__)
 MAX_LIMIT = max(1, API_MAX_LIMIT)
 
 
+@login_required()
 @render_response()
-def index(request, super_category=None):
+def index(request, super_category=None, conn=None, **kwargs):
     """
     Home page shows a list of groups OR a set of 'categories' from
     user-configured queries.
@@ -51,12 +52,6 @@ def index(request, super_category=None):
         context['category_queries'] = json.dumps(category_queries)
         return context
 
-    return index_with_login(request)
-
-
-@login_required()
-@render_response()
-def index_with_login(request, conn=None, **kwargs):
     my_groups = list(conn.getGroupsMemberOf())
 
     # Need a custom query to get 1 (random) image per Project


### PR DESCRIPTION
See https://github.com/ome/omero-gallery/pull/42#issuecomment-527377318

This adds ```@login_required()``` decorator to the gallery home page, meaning that non-public users have to login.
NB: The need to login for the new gallery was omitted before since all data was sometimes loaded from a *different* public server (e.g. IDR) so we didn't *need* to login locally. But this configuration is edge case and not needed in any of our workflows.
More often the lack of ```@login_required()``` on the home page would mean the page itself would load but no data would load (permission denied) and no login requested.

To test:
 - Go to https://py3-ci.openmicroscopy.org/web/gallery
 - Should get redirected to login screen and then back to gallery after login