### PR TITLE
decode base64 data for gallery thumbnails

### DIFF
--- a/omero_gallery/views.py
+++ b/omero_gallery/views.py
@@ -430,8 +430,9 @@ def api_thumbnails(request, conn=None, **kwargs):
             t = thumbnails[i]
             if len(t) > 0:
                 # replace thumbnail urls by base64 encoded image
-                rv[obj_id]["thumbnail"] = ("data:image/jpeg;base64,%s"
-                                           % base64.b64encode(t))
+                rv[obj_id]["thumbnail"] = ("data:image/jpeg;base64,%s" %
+                                           base64.b64encode(t).decode("utf-8"))
+
         except KeyError:
             logger.error("Thumbnail not available. (img id: %d)" % i)
     return rv


### PR DESCRIPTION
Fixes the bug noticed at today's demo where gallery thumnbails weren't showing up on the front page.
To test, go to https://py3-ci.openmicroscopy.org/web/gallery/ and check thumbnails are displayed.