### PR TITLE
new UI docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,18 +145,19 @@ Queries can use the ``AND`` and ``OR`` keywords to combine queries::
 **omero.web.gallery.filter_keys**
 
 If this is configured then the gallery will allow filtering of Screens and
-Projects by Key:Value pairs linked to them. This list defines which Keys the
-user can choose in the UI. On selecting a Key, the user will be able to
-filter by Values typed into an auto-complete field.
+Projects by Key:Value pairs linked to them, or use ``Name`` to filter by Name.
+This list defines which Keys the user can choose in the UI.
+On selecting a Key, the user will be able to filter by Values typed into
+an auto-complete field.
 
 Each item is a simple string (matching the Key) or an object with a ``label``
 and ``value``, where ``value`` matches the Key. An example based on IDR::
 
     $ omero config set omero.web.gallery.filter_keys '[
-        {"label": "Name (IDR number)", "value": "Name"},
+        "Name",
         "Imaging Method",
         "Organism",
-        "Publication Authors"
+        {"label": "Publication Authors", "value": "Authors"}
     ]'
 
 License

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ OMERO.gallery overview
 This application supports 2 alternative views of your data in OMERO, which can
 be chosen and customised via config settings:
 
- - Default UI (no config): Browse `Group > Project > Dataset > Image`
- - Categories UI: Show categories of interest. Allow filtering by map annotations.
+* Default UI (no config): Browse `Group > Project > Dataset > Image`
+* Categories UI: Show categories of interest. Allow filtering by map annotations.
 
 For both views, public access can be enabled
 `as described here <https://docs.openmicroscopy.org/latest/omero/sysadmins/public.html>`_,
@@ -96,19 +96,19 @@ and they are annotated with Key-Value data in the form of Map Annotations,
 for example ``Study Type: 3D-tracking``.
 The UI supports several features based on these Key-Value attributes:
 
- - Home page shows 'Categories' that are defined by queries on Map Annotations.
- - Filter studies by Map Annotations.
+* Home page shows 'Categories' that are defined by queries on Map Annotations.
+* Filter studies by Map Annotations.
 
 If Images are also annotated with Map Annotations and
 https://github.com/ome/omero-mapr/ is installed then you can:
 
- - Find Studies containing Images that match queries on their Map Annotations.
+* Find Studies containing Images that match queries on their Map Annotations.
 
 
 Configuring the Categories UI
 -----------------------------
 
-*omero.web.gallery.category_queries*
+**omero.web.gallery.category_queries**
 
 To enable the Categories UI, you must set ``omero.web.gallery.category_queries``.
 Each Category is defined by a display ``label``, a ``query`` to select the Projects

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ Replace the "Welcome to OMERO.gallery" heading on the home page.
 **omero.web.gallery.top_right_links:**
 This specifies a list of links as {'text':'Text','href':'www.url'} for the
 top-right of each page. If a link contains 'submenu':[ ] with more links,
-these will be shown in a dropdown menu"::
+these will be shown in a dropdown menu::
 
     $ omero config set omero.web.gallery.top_right_links '[
         {"text":"OME", "href":"https://www.openmicroscopy.org/"}

--- a/README.rst
+++ b/README.rst
@@ -160,14 +160,69 @@ and ``value``, where ``value`` matches the Key. An example based on IDR::
         {"label": "Publication Authors", "value": "Authors"}
     ]'
 
+
+**omero.web.gallery.title**
+
+    Sets the html page ```<title>title</title>``` for gallery pages.
+
+
 **omero.web.gallery.top_left_logo**
 
 This setting can be used to replace the 'OMERO' logo at the top-left of the
 page with an image hosted elsewhere (png, jpeg or svg). It will be displayed
-with height of 33 pixels and maximum width of 200 pixels.
+with height of 33 pixels and maximum width of 200 pixels::
 
     $ omero config set omero.web.gallery.top_left_logo '{"src": "https://www.openmicroscopy.org/img/logos/ome-main-nav.svg"}'
 
+
+**omero.web.gallery.heading**
+
+Replace the "Welcome to OMERO.gallery" heading on the home page.
+
+
+**omero.web.gallery.top_right_links**
+
+This specifies a list of links as {'text':'Text','href':'www.url'} for the
+top-right of each page. If a link contains 'submenu':[ ] with more links,
+these will be shown in a dropdown menu"::
+
+    $ omero config set omero.web.gallery.top_right_links '[
+        {"text":"OME", "href":"https://www.openmicroscopy.org/"}
+    ]'
+
+**omero.web.gallery.favicon**
+
+Set a URL to a favicon to use for the browser.
+
+**omero.web.gallery.subheading_html**
+
+Set some HTML to show as a sub-heading on the home page, within a <p> tag::
+
+    $ omero config set omero.web.gallery.subheading_html "This is an image gallery using <b>OMERO</b>."
+
+**omero.web.gallery.footer_html**
+
+Set some HTML to show as a footer on each page::
+
+    $ omero config set omero.web.gallery.footer_html "<a href='https://blog.openmicroscopy.org/'>Blog</a>"
+
+**omero.web.gallery.study_short_name**
+
+This specifies a short name for Screen or Project to show above the study Image
+in the categories or search page, instead of the default 'Project: 123'.
+The list allows us to try multiple methods, using the first that works.
+Each object in the list has e.g. {'key': 'Name'}. The 'key' can be Name,
+Description or the key for a Key:Value pair on the object.
+If a 'regex' and 'template' are specified, we try name.replace(regex, template).
+In this example, we check for a Key:Value named "Title". If that is not found,
+then we use a regex based on the object's Name. This example is from the IDR,
+where we want to create a short name like ``idr0001A`` from a Name
+like: ``idr0001-graml-sysgro/screenA``::
+
+    $ omero config set omero.web.gallery.study_short_name '[
+        {"key":"Title"},
+        {"key":"Name", "regex": "^(.*?)-.*?(.)$", "template": "$1$2"},
+    ]'
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -125,23 +125,23 @@ Screens), you can simply sort by Name or creation Date. This example defines
 2 Categories: "All Studies" to show the first 50 studies by Name and
 "Recent" to list the last 20 studies by Date (most recent)::
 
-    $ omero config set omero.web.gallery.category_queries '{ \
-      "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"}, \
-      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"} \
+    $ omero config set omero.web.gallery.category_queries '{
+      "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"},
+      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"}
       }'
 
 Other categories are defined by queries on Map Annotations. For example, to
 show all Studies that have Key:Value of ``Study Type: 3D-tracking``::
 
-    $ omero config set omero.web.gallery.category_queries '{ \
-      "tracking":{"label":"3D tracking", "index":0, "query":"Study Type: 3D-tracking"} \
+    $ omero config set omero.web.gallery.category_queries '{
+      "tracking":{"label":"3D tracking", "index":0, "query":"Study Type: 3D-tracking"}
       }'
 
 Queries can use the ``AND`` and ``OR`` keywords to combine queries::
 
-    $ omero config set omero.web.gallery.category_queries '{ \
-      "time":{"label":"Time-lapse imaging", "index":0, "query":"Study Type: 3D-tracking OR Study Type: time"}, \
-      "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"} \
+    $ omero config set omero.web.gallery.category_queries '{
+      "time":{"label":"Time-lapse imaging", "index":0, "query":"Study Type: 3D-tracking OR Study Type: time"},
+      "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"}
       }'
 
 **omero.web.gallery.filter_keys**
@@ -155,10 +155,10 @@ Each item is a simple string (matching the Key) or an object with a ``label``
 and ``value``, where ``value`` matches the Key. An example based on IDR::
 
     $ omero config set omero.web.gallery.filter_keys '[
-        {"label": "Name (IDR number)", "value": "Name"}, \
-        "Imaging Method", \
-        "Organism", \
-        "Publication Authors"\
+        {"label": "Name (IDR number)", "value": "Name"},
+        "Imaging Method",
+        "Organism",
+        "Publication Authors"
     ]'
 
 License

--- a/README.rst
+++ b/README.rst
@@ -121,13 +121,11 @@ at https://idr.openmicroscopy.org/ and see the query for each as a tooltip on
 the label of each category.
 
 In the simplest case, if you do not have Map Annotations on Studies (Projects and
-Screens), you can simply sort by Name or creation Date. This example defines
-2 Categories: "All Studies" to show the first 50 studies by Name and
-"Recent" to list the last 20 studies by Date (most recent)::
+Screens), you can simply sort by Name. This example defines
+a Category: "All Studies" to show the first 50 studies by Name::
 
     $ omero config set omero.web.gallery.category_queries '{
-      "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"},
-      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"}
+      "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"}
       }'
 
 Other categories are defined by queries on Map Annotations. For example, to

--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,7 @@ https://github.com/ome/omero-mapr/ is installed then you can:
 Configuring the Categories UI
 -----------------------------
 
-**omero.web.gallery.category_queries**
-
+**omero.web.gallery.category_queries:**
 To enable the Categories UI, you must set ``omero.web.gallery.category_queries``.
 If this is not set, you will see the Default UI shown above and the other
 settings described below will be ignored.
@@ -142,8 +141,7 @@ Queries can use the ``AND`` and ``OR`` keywords to combine queries::
       "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"}
       }'
 
-**omero.web.gallery.filter_keys**
-
+**omero.web.gallery.filter_keys:**
 If this is configured then the gallery will allow filtering of Screens and
 Projects by Key:Value pairs linked to them, or use ``Name`` to filter by Name.
 This list defines which Keys the user can choose in the UI.
@@ -161,13 +159,11 @@ and ``value``, where ``value`` matches the Key. An example based on IDR::
     ]'
 
 
-**omero.web.gallery.title**
+**omero.web.gallery.title:**
+Sets the html page ```<title>title</title>``` for gallery pages.
 
-    Sets the html page ```<title>title</title>``` for gallery pages.
 
-
-**omero.web.gallery.top_left_logo**
-
+**omero.web.gallery.top_left_logo:**
 This setting can be used to replace the 'OMERO' logo at the top-left of the
 page with an image hosted elsewhere (png, jpeg or svg). It will be displayed
 with height of 33 pixels and maximum width of 200 pixels::
@@ -175,13 +171,11 @@ with height of 33 pixels and maximum width of 200 pixels::
     $ omero config set omero.web.gallery.top_left_logo '{"src": "https://www.openmicroscopy.org/img/logos/ome-main-nav.svg"}'
 
 
-**omero.web.gallery.heading**
-
+**omero.web.gallery.heading:**
 Replace the "Welcome to OMERO.gallery" heading on the home page.
 
 
-**omero.web.gallery.top_right_links**
-
+**omero.web.gallery.top_right_links:**
 This specifies a list of links as {'text':'Text','href':'www.url'} for the
 top-right of each page. If a link contains 'submenu':[ ] with more links,
 these will be shown in a dropdown menu"::
@@ -190,24 +184,20 @@ these will be shown in a dropdown menu"::
         {"text":"OME", "href":"https://www.openmicroscopy.org/"}
     ]'
 
-**omero.web.gallery.favicon**
-
+**omero.web.gallery.favicon:**
 Set a URL to a favicon to use for the browser.
 
-**omero.web.gallery.subheading_html**
-
+**omero.web.gallery.subheading_html:**
 Set some HTML to show as a sub-heading on the home page, within a <p> tag::
 
     $ omero config set omero.web.gallery.subheading_html "This is an image gallery using <b>OMERO</b>."
 
-**omero.web.gallery.footer_html**
-
+**omero.web.gallery.footer_html:**
 Set some HTML to show as a footer on each page::
 
     $ omero config set omero.web.gallery.footer_html "<a href='https://blog.openmicroscopy.org/'>Blog</a>"
 
-**omero.web.gallery.study_short_name**
-
+**omero.web.gallery.study_short_name:**
 This specifies a short name for Screen or Project to show above the study Image
 in the categories or search page, instead of the default 'Project: 123'.
 The list allows us to try multiple methods, using the first that works.

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,9 @@ Configuring the Categories UI
 **omero.web.gallery.category_queries**
 
 To enable the Categories UI, you must set ``omero.web.gallery.category_queries``.
+If this is not set, you will see the Default UI shown above and the other
+settings described below will be ignored.
+
 Each Category is defined by a display ``label``, a ``query`` to select the Projects
 and Screens and an ``index`` to specify the order they appear on the page.
 Most of the examples below are used in the IDR. You can view the Categories
@@ -124,23 +127,39 @@ Screens), you can simply sort by Name or creation Date. This example defines
 
     $ omero config set omero.web.gallery.category_queries '{ \
       "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"}, \
-      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"}, \
+      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"} \
       }'
 
 Other categories are defined by queries on Map Annotations. For example, to
 show all Studies that have Key:Value of ``Study Type: 3D-tracking``::
 
     $ omero config set omero.web.gallery.category_queries '{ \
-      "tracking":{"label":"3D tracking", "index":0, "query":"Study Type: 3D-tracking"}, \
+      "tracking":{"label":"3D tracking", "index":0, "query":"Study Type: 3D-tracking"} \
       }'
 
 Queries can use the ``AND`` and ``OR`` keywords to combine queries::
 
     $ omero config set omero.web.gallery.category_queries '{ \
       "time":{"label":"Time-lapse imaging", "index":0, "query":"Study Type: 3D-tracking OR Study Type: time"}, \
-      "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"}, \
+      "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"} \
       }'
 
+**omero.web.gallery.filter_keys**
+
+If this is configured then the gallery will allow filtering of Screens and
+Projects by Key:Value pairs linked to them. This list defines which Keys the
+user can choose in the UI. On selecting a Key, the user will be able to
+filter by Values typed into an auto-complete field.
+
+Each item is a simple string (matching the Key) or an object with a ``label``
+and ``value``, where ``value`` matches the Key. An example based on IDR::
+
+    $ omero config set omero.web.gallery.filter_keys '[
+        {"label": "Name (IDR number)", "value": "Name"}, \
+        "Imaging Method", \
+        "Organism", \
+        "Publication Authors"\
+    ]'
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,15 @@ and ``value``, where ``value`` matches the Key. An example based on IDR::
         {"label": "Publication Authors", "value": "Authors"}
     ]'
 
+**omero.web.gallery.top_left_logo**
+
+This setting can be used to replace the 'OMERO' logo at the top-left of the
+page with an image hosted elsewhere (png, jpeg or svg). It will be displayed
+with height of 33 pixels and maximum width of 200 pixels.
+
+    $ omero config set omero.web.gallery.top_left_logo '{"src": "https://www.openmicroscopy.org/img/logos/ome-main-nav.svg"}'
+
+
 License
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,25 @@ This is due to a Django Framework compatibility and to a required package reorga
 OMERO.gallery overview
 ======================
 
-This application is designed to support browsing of images via the hierarchy of
-Group > Project > Dataset > Image.
+This application supports 2 alternative views of your data in OMERO, which can
+be chosen and customised via config settings:
 
-Public access can be enabled `as described here <https://docs.openmicroscopy.org/latest/omero/sysadmins/public.html>`_, otherwise
-users will see the standard web login screen.
+ - Default UI (no config): Browse `Group > Project > Dataset > Image`
+ - Categories UI: Show categories of interest. Allow filtering by map annotations.
+
+For both views, public access can be enabled
+`as described here <https://docs.openmicroscopy.org/latest/omero/sysadmins/public.html>`_,
+otherwise users will see the standard web login screen.
+Once logged-in (as a regular user or public user), the data displayed will
+include all data accessible to that user via the normal OMERO permissions.
+
+
+Default UI
+----------
+
+This view supports minimal functionality required for browsing the hierarchy
+from Groups -> Projects -> Datasets -> Images. Screen/Plate/Well data is
+not supported in this UI.
 
 The home page will display all the available groups that the user can access, with a random
 thumbnail from each group. The number of Projects, Datasets and Images within each group
@@ -71,6 +85,62 @@ from a chosen Dataset (or you can browse to the Dataset itself by clicking the D
 Clicking a thumbnail will take you directly to the full image viewer.
 
 .. image:: https://ome.github.io/omero-gallery/images/webgateway_viewer.png
+
+
+Categories UI
+-------------
+
+This view was originally developed for use in the IDR and can be seen at
+https://idr.openmicroscopy.org/. In the IDR, a "Study" is a Project or Screen
+and they are annotated with Key-Value data in the form of Map Annotations,
+for example ``Study Type: 3D-tracking``.
+The UI supports several features based on these Key-Value attributes:
+
+ - Home page shows 'Categories' that are defined by queries on Map Annotations.
+ - Filter studies by Map Annotations.
+
+If Images are also annotated with Map Annotations and
+https://github.com/ome/omero-mapr/ is installed then you can:
+
+ - Find Studies containing Images that match queries on their Map Annotations.
+
+
+Configuring the Categories UI
+-----------------------------
+
+*omero.web.gallery.category_queries*
+
+To enable the Categories UI, you must set ``omero.web.gallery.category_queries``.
+Each Category is defined by a display ``label``, a ``query`` to select the Projects
+and Screens and an ``index`` to specify the order they appear on the page.
+Most of the examples below are used in the IDR. You can view the Categories
+at https://idr.openmicroscopy.org/ and see the query for each as a tooltip on
+the label of each category.
+
+In the simplest case, if you do not have Map Annotations on Studies (Projects and
+Screens), you can simply sort by Name or creation Date. This example defines
+2 Categories: "All Studies" to show the first 50 studies by Name and
+"Recent" to list the last 20 studies by Date (most recent)::
+
+    $ omero config set omero.web.gallery.category_queries '{ \
+      "all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"}, \
+      "recent":{"label":"Recent", "index":1, "query":"LAST20:Date"}, \
+      }'
+
+Other categories are defined by queries on Map Annotations. For example, to
+show all Studies that have Key:Value of ``Study Type: 3D-tracking``::
+
+    $ omero config set omero.web.gallery.category_queries '{ \
+      "tracking":{"label":"3D tracking", "index":0, "query":"Study Type: 3D-tracking"}, \
+      }'
+
+Queries can use the ``AND`` and ``OR`` keywords to combine queries::
+
+    $ omero config set omero.web.gallery.category_queries '{ \
+      "time":{"label":"Time-lapse imaging", "index":0, "query":"Study Type: 3D-tracking OR Study Type: time"}, \
+      "screens":{"label":"High-content screening (human)", "index":1, "query":"Organism:Homo sapiens AND Study Type:high content screen"}, \
+      }'
+
 
 License
 -------

--- a/omero_gallery/static/gallery/categories.js
+++ b/omero_gallery/static/gallery/categories.js
@@ -362,4 +362,6 @@ fetch(BASE_URL + 'mapr/api/config/').then(function (response) {
     document.getElementById('maprKeys').style.display = 'block';
     document.getElementById('search-form').style.display = 'block';
   }
+})["catch"](function (err) {
+  console.log("mapr not installed (config not available)");
 });

--- a/omero_gallery/static/gallery/search.js
+++ b/omero_gallery/static/gallery/search.js
@@ -472,7 +472,7 @@ function render(filterFunc) {
     filterMessage = noStudiesMessage();
   } else if (studiesToRender.length < model.studies.length) {
     var configId = document.getElementById("maprConfig").value.replace('mapr_', '');
-    configId = mapr_settings[configId] || configId;
+    configId = mapr_settings && mapr_settings[configId] || configId;
     var maprValue = document.getElementById('maprQuery').value;
     filterMessage = "<p class=\"filterMessage\">\n      Found <strong>".concat(studiesToRender.length, "</strong> studies with\n      <strong>").concat(configId, "</strong>: <strong>").concat(maprValue, "</strong></p>");
   }

--- a/omero_gallery/static/gallery/search.js
+++ b/omero_gallery/static/gallery/search.js
@@ -685,4 +685,6 @@ fetch(BASE_URL + 'mapr/api/config/').then(function (response) {
   }
 
   populateInputsFromSearch();
+})["catch"](function (err) {
+  console.log("mapr not installed (config not available)");
 });

--- a/src/categories.js
+++ b/src/categories.js
@@ -382,4 +382,7 @@ fetch(BASE_URL + 'mapr/api/config/')
       document.getElementById('maprKeys').style.display = 'block';
       document.getElementById('search-form').style.display = 'block';
     }
+  })
+  .catch(function(err) {
+      console.log("mapr not installed (config not available)");
   });

--- a/src/search.js
+++ b/src/search.js
@@ -698,4 +698,6 @@ fetch(BASE_URL + 'mapr/api/config/')
       document.getElementById('search-form').style.display = 'block';
     }
     populateInputsFromSearch();
+  }).catch(function(err) {
+    console.log("mapr not installed (config not available)");
   });

--- a/src/search.js
+++ b/src/search.js
@@ -469,7 +469,7 @@ function render(filterFunc) {
     filterMessage = noStudiesMessage();
   } else if (studiesToRender.length < model.studies.length) {
     let configId = document.getElementById("maprConfig").value.replace('mapr_', '');
-    configId = mapr_settings[configId] || configId;
+    configId = (mapr_settings && mapr_settings[configId]) || configId;
     let maprValue = document.getElementById('maprQuery').value;
     filterMessage = `<p class="filterMessage">
       Found <strong>${ studiesToRender.length }</strong> studies with


### PR DESCRIPTION
Aim to document the un-released 'categories' UI.
There was interest in using the new UI at the Dundee workshop in September and elsewhere.

Staged at https://github.com/will-moore/omero-gallery/blob/new_ui_docs/README.rst

To test:
 - Try settings based on the examples (also need to add some Map Annotations for some settings)

This needs to be merged as part of the full release of the 'IDR' UI.