### PR TITLE
Fix studies expanding outside page

### DIFF
--- a/omero_gallery/static/gallery/categories.js
+++ b/omero_gallery/static/gallery/categories.js
@@ -188,10 +188,10 @@ function render() {
       // list studies in a grid, without category.label
       div.innerHTML = "<div id=\"".concat(elementId, "\" class=\"row horizontal studiesLayout\"></div>");
     } else {
-      div.innerHTML = "<h1 title=\"".concat(query, "\">").concat(cat.label, " (").concat(matches.length, ")</h1>\n        <div class=\"category\">\n          <div id=\"").concat(elementId, "\"></div>\n        </div>\n      ");
-    }
+      div.innerHTML = "\n        <h1 title=\"".concat(query, "\" style=\"margin-left:10px\">\n          ").concat(cat.label, " (").concat(matches.length, ")\n        </h1>\n        <div class=\"category\">\n          <div id=\"").concat(elementId, "\"></div>\n        </div>\n      ");
+    } // div.className = "row";
 
-    div.className = "row";
+
     document.getElementById('studies').appendChild(div);
     matches.forEach(function (study) {
       return renderStudy(study, elementId, linkFunc);

--- a/src/categories.js
+++ b/src/categories.js
@@ -193,13 +193,15 @@ function render() {
       // list studies in a grid, without category.label
       div.innerHTML = `<div id="${elementId}" class="row horizontal studiesLayout"></div>`;
     } else {
-      div.innerHTML = `<h1 title="${query}">${cat.label} (${ matches.length })</h1>
+      div.innerHTML = `
+        <h1 title="${query}" style="margin-left:10px">
+          ${cat.label} (${ matches.length })
+        </h1>
         <div class="category">
           <div id="${elementId}"></div>
         </div>
       `;
     }
-    div.className = "row";
     document.getElementById('studies').appendChild(div);
 
     matches.forEach(study => renderStudy(study, elementId, linkFunc));


### PR DESCRIPTION
This tweaks the css for categories page to fix the Titles and image panels expanding outside the screen:

To test:
 - Go to: https://merge-ci.openmicroscopy.org/web/gallery/ (login as user-3)
 - Resize browser window small as possible, or test on a phone.
 - Text and images shouldn't expand outside the page:

Before:

<img width="600" alt="Screenshot 2020-08-15 at 20 59 58" src="https://user-images.githubusercontent.com/900055/90320639-b8d0a480-df3a-11ea-86c7-8023aa9f48ac.png">
