### PR TITLE
Fix 2-cols single category

### DIFF
--- a/omero_gallery/static/gallery/categories.js
+++ b/omero_gallery/static/gallery/categories.js
@@ -187,10 +187,10 @@ function render() {
     if (categories.length == 1) {
       // list studies in a grid, without category.label
       div.innerHTML = "<div id=\"".concat(elementId, "\" class=\"row horizontal studiesLayout\"></div>");
+      div.className = "row";
     } else {
       div.innerHTML = "\n        <h1 title=\"".concat(query, "\" style=\"margin-left:10px\">\n          ").concat(cat.label, " (").concat(matches.length, ")\n        </h1>\n        <div class=\"category\">\n          <div id=\"").concat(elementId, "\"></div>\n        </div>\n      ");
-    } // div.className = "row";
-
+    }
 
     document.getElementById('studies').appendChild(div);
     matches.forEach(function (study) {

--- a/src/categories.js
+++ b/src/categories.js
@@ -192,6 +192,7 @@ function render() {
     if (categories.length == 1) {
       // list studies in a grid, without category.label
       div.innerHTML = `<div id="${elementId}" class="row horizontal studiesLayout"></div>`;
+      div.className = "row"
     } else {
       div.innerHTML = `
         <h1 title="${query}" style="margin-left:10px">


### PR DESCRIPTION
Re-add class row IF only single category shown.
Fixes #73
This fixes a bug from https://github.com/ome/omero-gallery/pull/68/ when used with single-category layout.

To test:
 - Check that you get 3 columns with single category. e.g.
```
omero config set omero.web.gallery.category_queries '{"all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"}}'
```
 - Check that with multiple categories, still looks good on mobile (small screen) - as fixed in #68. e.g. tested locally with
```
omero config set omero.web.gallery.category_queries '{"all":{"label":"All Studies", "index":0, "query":"FIRST50:Name"},"idr":{"label":"IDR Studies", "index":1, "query":"Study Type: IDR"}}'
```