### PR TITLE
Filter studies by group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,8 @@ Queries can use the ``AND`` and ``OR`` keywords to combine queries::
 
 **omero.web.gallery.filter_keys:**
 If this is configured then the gallery will allow filtering of Screens and
-Projects by Key:Value pairs linked to them, or use ``Name`` to filter by Name.
+Projects by Key:Value pairs linked to them, or use ``Name`` to filter by Name
+or ``Group`` to filter by Group.
 This list defines which Keys the user can choose in the UI.
 On selecting a Key, the user will be able to filter by Values typed into
 an auto-complete field.

--- a/omero_gallery/static/gallery/categories.js
+++ b/omero_gallery/static/gallery/categories.js
@@ -1,6 +1,6 @@
 "use strict";
 
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 //   This program is free software: you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as
@@ -63,6 +63,8 @@ $("#maprQuery").keyup(function (event) {
 
       if (configId === 'Name') {
         matches = model.getStudiesNames(request.term);
+      } else if (configId === 'Group') {
+        matches = model.getStudiesGroups(request.term);
       } else {
         matches = model.getKeyValueAutoComplete(configId, request.term);
       }

--- a/omero_gallery/static/gallery/model.js
+++ b/omero_gallery/static/gallery/model.js
@@ -16,7 +16,7 @@ function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = 
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 //   This program is free software: you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as
@@ -55,6 +55,28 @@ StudiesModel.prototype.getStudyById = function getStudyById(typeId) {
 StudiesModel.prototype.getStudiesNames = function getStudiesNames(filterQuery) {
   var names = this.studies.map(function (s) {
     return s.Name;
+  });
+
+  if (filterQuery) {
+    names = names.filter(function (name) {
+      return name.toLowerCase().indexOf(filterQuery) > -1;
+    });
+  }
+
+  names.sort(function (a, b) {
+    return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
+  });
+  return names;
+};
+
+StudiesModel.prototype.getStudiesGroups = function getStudiesGroups(filterQuery) {
+  var names = [];
+  this.studies.forEach(function (study) {
+    var groupName = study['omero:details'].group.Name;
+
+    if (names.indexOf(groupName) === -1) {
+      names.push(groupName);
+    }
   });
 
   if (filterQuery) {

--- a/omero_gallery/static/gallery/search.js
+++ b/omero_gallery/static/gallery/search.js
@@ -1,6 +1,6 @@
 "use strict";
 
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 //   This program is free software: you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as
@@ -255,6 +255,8 @@ $("#maprQuery").keyup(function (event) {
 
       if (configId === 'Name') {
         matches = model.getStudiesNames(request.term);
+      } else if (configId === 'Group') {
+        matches = model.getStudiesGroups(request.term);
       } else {
         matches = model.getKeyValueAutoComplete(configId, request.term);
       }
@@ -371,6 +373,11 @@ function filterAndRender() {
 
       if (configId === 'Name') {
         return study.Name.toLowerCase().indexOf(toMatch) > -1;
+      }
+
+      if (configId === 'Group') {
+        var group = study['omero:details'].group;
+        return group.Name.toLowerCase().indexOf(toMatch) > -1;
       } // Filter by Map-Annotation Key-Value
 
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "images"
   ],
   "author": "OME",
-  "license": "GPLv3",
+  "license": "AGPL-3.0",
   "bugs": {
     "url": "https://github.com/ome/omero-gallery/issues"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "images"
   ],
   "author": "OME",
-  "license": "MIT",
+  "license": "GPLv3",
   "bugs": {
     "url": "https://github.com/ome/omero-gallery/issues"
   },

--- a/src/categories.js
+++ b/src/categories.js
@@ -1,4 +1,4 @@
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 
 //   This program is free software: you can redistribute it and/or modify
@@ -70,6 +70,8 @@ $("#maprQuery")
           let matches;
           if (configId === 'Name') {
             matches = model.getStudiesNames(request.term);
+          } else if (configId === 'Group') {
+            matches = model.getStudiesGroups(request.term);
           } else {
             matches = model.getKeyValueAutoComplete(configId, request.term);
           }

--- a/src/model.js
+++ b/src/model.js
@@ -1,4 +1,4 @@
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 
 //   This program is free software: you can redistribute it and/or modify
@@ -47,6 +47,21 @@ StudiesModel.prototype.getStudiesNames = function getStudiesNames(filterQuery) {
     names = names.filter(name => name.toLowerCase().indexOf(filterQuery) > -1);
   }
   names.sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1: -1);
+  return names;
+}
+
+StudiesModel.prototype.getStudiesGroups = function getStudiesGroups(filterQuery) {
+  let names = [];
+  this.studies.forEach(study => {
+    var groupName = study['omero:details'].group.Name;
+    if (names.indexOf(groupName) === -1) {
+      names.push(groupName);
+    }
+  });
+  if (filterQuery) {
+    names = names.filter(name => name.toLowerCase().indexOf(filterQuery) > -1);
+  }
+  names.sort((a, b) => a.toLowerCase() > b.toLowerCase() ? 1 : -1);
   return names;
 }
 

--- a/src/search.js
+++ b/src/search.js
@@ -1,4 +1,4 @@
-//   Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+//   Copyright (C) 2019-2020 University of Dundee & Open Microscopy Environment.
 //   All rights reserved.
 
 //   This program is free software: you can redistribute it and/or modify
@@ -256,6 +256,8 @@ $("#maprQuery")
           let matches;
           if (configId === 'Name') {
             matches = model.getStudiesNames(request.term);
+          } else if (configId === 'Group') {
+            matches = model.getStudiesGroups(request.term);
           } else {
             matches = model.getKeyValueAutoComplete(configId, request.term);
           }
@@ -365,6 +367,10 @@ function filterAndRender() {
       let toMatch = value.toLowerCase();
       if (configId === 'Name') {
         return study.Name.toLowerCase().indexOf(toMatch) > -1;
+      }
+      if (configId === 'Group') {
+        var group = study['omero:details'].group;
+        return group.Name.toLowerCase().indexOf(toMatch) > -1;
       }
       // Filter by Map-Annotation Key-Value
       let show = false;


### PR DESCRIPTION
See https://github.com/ome/omero-gallery/issues/28#issuecomment-747385826 and https://forum.image.sc/t/customization-of-omero-gallery/46336/7

This allows filtering of Studies in the 'Categories' UI by Group name.

To test:
- Add "Group" to the filter keys:
-```$ omero config append omero.web.gallery.filter_keys '"Group"'``` (NB: merge-ci currently configured with `["Name", "Group"]`).
- Choose to filter by group on the home page. This should populate the auto-complete with group names:
- Pick an auto-complete option (group name) to take you to the 'search' page where the Studies should be filtered by Group:

![Screenshot 2020-12-21 at 12 21 48](https://user-images.githubusercontent.com/900055/102776719-2aa47900-4387-11eb-9809-be9c55a8f620.png)


cc @abhamacher