### PR TITLE
grabbing image IDs instead of objects to generate group view

### DIFF
--- a/omero_gallery/views.py
+++ b/omero_gallery/views.py
@@ -77,9 +77,15 @@ def index(request, super_category=None, conn=None, **kwargs):
     groups = []
     for g in my_groups:
         conn.SERVICE_OPTS.setOmeroGroup(g.id)
-        images = list(conn.getObjects("Image", params=params))
-        if len(images) == 0:
+        image_ids = query_service.projection(
+                                "SELECT i.id FROM Image i",
+                                params,
+                                conn.SERVICE_OPTS
+                )
+        if len(image_ids[0]) == 0:
             continue        # Don't display empty groups
+        else:
+            image = conn.getObject("Image", image_ids[0][0]._val)
         p_count = query_service.projection(
             query % 'Project', None, conn.SERVICE_OPTS)
         d_count = query_service.projection(
@@ -93,7 +99,7 @@ def index(request, super_category=None, conn=None, **kwargs):
             'projectCount': p_count[0][0]._val,
             'datasetCount': d_count[0][0]._val,
             'imageCount': i_count[0][0]._val,
-            'image': len(images) > 0 and images[0] or None})
+            'image': len(image_ids[0]) > 0 and image or None})
 
     # This is used by @render_response
     context = {'template': "webgallery/index.html"}

--- a/omero_gallery/views.py
+++ b/omero_gallery/views.py
@@ -82,7 +82,7 @@ def index(request, super_category=None, conn=None, **kwargs):
                                 params,
                                 conn.SERVICE_OPTS
                 )
-        if len(image_ids[0]) == 0:
+        if len(image_ids) == 0:
             continue        # Don't display empty groups
         else:
             image = conn.getObject("Image", image_ids[0][0]._val)
@@ -99,7 +99,7 @@ def index(request, super_category=None, conn=None, **kwargs):
             'projectCount': p_count[0][0]._val,
             'datasetCount': d_count[0][0]._val,
             'imageCount': i_count[0][0]._val,
-            'image': len(image_ids[0]) > 0 and image or None})
+            'image': len(image_ids) > 0 and image or None})
 
     # This is used by @render_response
     context = {'template': "webgallery/index.html"}


### PR DESCRIPTION
We (myself, @mellertd and @perlman) have noticed that, in our public server, the front Gallery page would take VERY long to load. So we decided to investigate. It seems that the code that generates that view grabs a list of every `Image` object belonging to a group, which is VERY slow. So I've put together a quick fix that grabs a list of every `Image` _ID_ instead, and then only grabs the object for the `Image` that will be used as a preview. 

I've run both bits of code (lines 67 to 96 of current code and equivalent bit on new code) against our public server. 

Current code:
Time elapsed: 14.50310492515564
`groups` object at the end: `{'id': 53, 'name': 'Public', 'description': 'Public data', 'projectCount': 12, 'datasetCount': 913, 'imageCount': 25764, 'image': <_ImageWrapper id=163301>}`

New code: 
Time elapsed: 0.163618803024292
`groups` object at the end: `{'id': 53, 'name': 'Public', 'description': 'Public data', 'projectCount': 12, 'datasetCount': 913, 'imageCount': 25764, 'image': <_ImageWrapper id=163301>}`

Same result, slightly faster 😄 